### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ yarn
 
 Copy/Rename the `.env_example` to `.env` and fill out the values:
 
+[![Run on Repl.it](https://repl.it/badge/github/iCrawl/discord-music-bot)](https://repl.it/github/iCrawl/discord-music-bot)
+
 ```
 DISCORD_TOKEN=
 DISCORD_PREFIX=


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).